### PR TITLE
Update http_proxy validation to support IPs too

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,9 +11,20 @@ class httpproxy (
   $purge_apt_conf  = false,
 ){
 
-  # Validates that $http_proxy and $http_proxy_port are domain names and ports respectively.
-  if $http_proxy { validate_re($http_proxy, '^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$') }
-  if $http_proxy_port { validate_re($http_proxy_port, '^\d+$') }
+  # Validates that $http_proxy is a valid, usable domain name or IP address
+  if $http_proxy and size($http_proxy) > 3 {   # '.' is an RFC-valid domain name, but not usable in this context
+    if is_ip_address($http_proxy) or is_domain_name($http_proxy) {
+      $proxy_is_valid = true
+    } else {
+      # Invalid proxy specified - could also 'undef' the value an continue??
+      $proxy_is_valid = 'No, the proxy is not valid'
+    }
+    validate_bool($proxy_is_valid)
+  }
+  # Validate that $http_proxy_port is a valid port number
+  if $http_proxy_port {
+    validate_integer($http_proxy_port, 65535, 0)
+  }
   validate_bool($purge_apt_conf)
 
   # Checks if $http_proxy contains a string. If $http_proxy is null $ensure is set to absent.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,15 +14,13 @@ class httpproxy (
   # Validates that $http_proxy is a valid, usable domain name or IP address
   if $http_proxy and size($http_proxy) > 3 {   # '.' is an RFC-valid domain name, but not usable in this context
     if is_ipv4_address($http_proxy) or is_domain_name($http_proxy) {
-      $proxy_is_valid = true
+      $_http_proxy = $http_proxy
     } elsif is_ipv6_address($http_proxy) { # IPv6 needs to be enclosed in []
-      $http_proxy = enclose_ipv6($http_proxy)
-      $proxy_is_valid = true
+      $_http_proxy = enclose_ipv6($http_proxy)
     } else {
-      # Invalid proxy specified - could also 'undef' the value an continue??
-      $proxy_is_valid = 'No, the proxy is not valid'
+      # Invalid proxy format
+      fail("The http_proxy specified ( ${http_proxy} ) is not a valid IP or hostname.")
     }
-    validate_bool($proxy_is_valid)
   }
   # Validate that $http_proxy_port is a valid port number
   if $http_proxy_port {
@@ -30,9 +28,9 @@ class httpproxy (
   }
   validate_bool($purge_apt_conf)
 
-  # Checks if $http_proxy contains a string. If $http_proxy is null $ensure is set to absent.
-  # If $http_proxy contains a string then $ensure is set to present.
-  $ensure = $http_proxy ? {
+  # Checks if $_http_proxy contains a string. If $_http_proxy is null $ensure is set to absent.
+  # If $_http_proxy contains a string then $ensure is set to present.
+  $ensure = $_http_proxy ? {
     undef   => 'absent',
     default => 'present',
   }
@@ -47,9 +45,9 @@ class httpproxy (
 
   # Checks if $http_proxy contains a string. If it is null, $proxy_uri is set to null.
   # Otherwise, it will concatenate $http_proxy and $proxy_port_string.
-  $proxy_uri = $http_proxy ? {
+  $proxy_uri = $_http_proxy ? {
     undef   => undef,
-    default => "http://${http_proxy}${proxy_port_string}",
+    default => "http://${_http_proxy}${proxy_port_string}",
   }
 
   # Boolean parameter for class selection

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,10 @@ class httpproxy (
 
   # Validates that $http_proxy is a valid, usable domain name or IP address
   if $http_proxy and size($http_proxy) > 3 {   # '.' is an RFC-valid domain name, but not usable in this context
-    if is_ip_address($http_proxy) or is_domain_name($http_proxy) {
+    if is_ipv4_address($http_proxy) or is_domain_name($http_proxy) {
+      $proxy_is_valid = true
+    } elsif is_ipv6_address($http_proxy) { # IPv6 needs to be enclosed in []
+      $http_proxy = enclose_ipv6($http_proxy)
       $proxy_is_valid = true
     } else {
       # Invalid proxy specified - could also 'undef' the value an continue??

--- a/manifests/package/apt.pp
+++ b/manifests/package/apt.pp
@@ -6,7 +6,7 @@ class httpproxy::package::apt {
   class { '::apt':
     proxy => {
       'ensure' => $httpproxy::packagemanager::ensure,
-      'host'   => $httpproxy::http_proxy,
+      'host'   => $httpproxy::_http_proxy,
       'port'   => $httpproxy::http_proxy_port,
     },
   }

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/MiamiOH/puppet-httpproxy/issues",
   "tags": ["proxy", "linux"],
   "dependencies": [
-    {"name": "puppetlabs/stdlib", "version_requirement": ">= 4.1.0 < 5.0.0"},
+    {"name": "puppetlabs/stdlib", "version_requirement": ">= 4.12.0 < 5.0.0"},
     {"name": "puppetlabs/inifile", "version_requirement": ">= 1.3.0 < 2.0.0"},
     {"name": "unibet/profiled", "version_requirement": ">= 0.1.4 < 1.0.0"},
     {"name": "puppetlabs/apt", "version_requirement": ">= 2.2.0 < 3.0.0"}


### PR DESCRIPTION
Update validation of http_proxy & http_proxy_port to be a bit more strict, as well as to allow IPv4 and IPv6 address as the http_proxy.
- http_proxy_port is checked to ensure it's in the appropriate range
- http_proxy is now checked using stdlib's  id_domain_name, is_ipv4_address, and is_ipv6_address functions
- If http_proxy is an IPv6 address, it is enclosed in brackets so that the $proxy_uri will be usable.
