### PR TITLE
updated metadata.json for puppetlabs/stdlib,puppetlabs/inifile, and p…

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,10 +9,10 @@
   "issues_url": "https://github.com/MiamiOH/puppet-httpproxy/issues",
   "tags": ["proxy", "linux"],
   "dependencies": [
-    {"name": "puppetlabs/stdlib", "version_requirement": ">= 4.25.0 < 5.0.0"},
-    {"name": "puppetlabs/inifile", "version_requirement": ">= 1.3.0 < 3.0.0"},
+    {"name": "puppetlabs/stdlib", "version_requirement": ">= 4.25.0 < 6.0.0"},
+    {"name": "puppetlabs/inifile", "version_requirement": ">= 1.3.0 < 4.0.0"},
     {"name": "unibet/profiled", "version_requirement": ">= 0.1.4 < 1.0.0"},
-    {"name": "puppetlabs/apt", "version_requirement": ">= 2.2.0 < 5.0.0"}
+    {"name": "puppetlabs/apt", "version_requirement": ">= 2.2.0 < 8.0.0"}
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
…uppetlabs/apt to match current releases

This is my first public PR, so apologies if my etiquette isn't proper.

The current versions of several modules on forge.puppetlabs.com have advanced beyond what your `metadata.json` allows.

I've just bumped the versions to clear these warnings.

Thank you for sharing a useful module with us!

Best regards,

John
---
John Klein
NC State Office of Information Technology
jaklein@ncsu.edu / https://oit.ncsu.edu/about/units/ss/central-services-and-integration/
