### PR TITLE
Switch apt proxy implementation

### DIFF
--- a/manifests/package/apt.pp
+++ b/manifests/package/apt.pp
@@ -2,13 +2,18 @@
 # Uses the puppetlabs-apt module to manage apt package manager proxies
 # https://forge.puppetlabs.com/puppetlabs/apt
 class httpproxy::package::apt {
+  contain apt
 
-  class { 'apt':
-    proxy => {
-      'ensure' => $httpproxy::packagemanager::ensure,
-      'host'   => $httpproxy::http_proxy,
-      'port'   => $httpproxy::http_proxy_port,
-    },
+  if !defined(Apt::Setting['conf-proxy']) {
+    $content = @("EOL"/L)
+    // This file is managed by Puppet. DO NOT EDIT.
+    Acquire::http::proxy "http://$httpproxy::http_proxy:$httpproxy::http_proxy_port/";
+    | EOL
+
+    apt::setting { 'conf-proxy':
+      ensure   => $httpproxy::packagemanager::ensure,
+      priority => '01',
+      content  => $content,
+    }
   }
-  contain 'apt'
 }

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.2.0 < 9.0.0"
+      "version_requirement": ">= 2.2.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This PR updates the implementation of the proxy configuration by using the `apt::settings` defined resource type instead of passing the configuration value through the `apt` class resource. 

This allows previous inclusions of the `apt` class without a duplicate resource error, and achieves the same end result, including executing the `apt_update` exec afterwards. By checking for a previous definition of `apt::setting` used by the main `apt` class when configuring a proxy setting there, we can avoid duplicate resource errors as well. 

The metadata has also been updated to include puppetlabs/apt version 9.x, since 9.0.2 is currently released and in testing works well with this module. 

All existing unit tests pass successfully, and a functional test switching between the old implementation and the new revealed no effective changes in the catalog. 

Alternate implementation of #11
Fixes #12 